### PR TITLE
Fix: package.json: "files" property

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "operations-orchestration-api",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "HPE's Operations Orchestration (OO) client API module for NodeJS",
   "main": "./lib/main.js",
   "scripts": {
@@ -8,7 +8,7 @@
     "coverage": "node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
   },
   "files": [
-    "./lib"
+    "lib"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
There is missing directory `lib` in last published version 2.0.0 in NPM.

Root of issue is in `package.json`, where is `files` property. Value `./lib` is wrong, correct is `lib`.